### PR TITLE
Move babel deps into devDependencies, add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "email": "aryeh.stiefel@idt.net"
     }
   ],
-  "dependencies": {
+  "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0"


### PR DESCRIPTION
It's not necessary for a consumer of this package to install the babel related dependencies.
