### PR TITLE
Fix Android displaying '?' instead correct symbol

### DIFF
--- a/native.js
+++ b/native.js
@@ -1,5 +1,6 @@
 "use strict";
-
+import 'core-js/es6/symbol';
+import 'core-js/fn/symbol/iterator';
 import {
   View,
   Text,
@@ -20,7 +21,7 @@ class NativeIniticon extends Component {
       return text;
     } else  {
       let normalized = (typeof (text.normalize) === 'function') ? text.normalize().trim() : text.trim();
-      let symbols = Array.from(normalized);
+      let symbols = [...normalized];
       let indexOfSpace = symbols.indexOf(' ');
       if (indexOfSpace < symbols.length && !single) {
         return (symbols[0] + symbols[indexOfSpace+1]).toUpperCase();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-initials",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "React Native library to generate Google Inbox style material list icons.",
   "author": {
     "name": "IDT Labs",
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "react": "^15.1.0",
-    "react-native": "*"
+    "react-native": "*",
+    "core-js": "*"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
polyfills are loaded only when needed