### PR TITLE
Change path to imported core-js

### DIFF
--- a/native.js
+++ b/native.js
@@ -1,6 +1,6 @@
 "use strict";
-import 'core-js/es6/symbol';
-import 'core-js/fn/symbol/iterator';
+import 'core-js/es/symbol';
+import 'core-js/features/symbol/iterator';
 import {
   View,
   Text,


### PR DESCRIPTION
In core-js@3 all stable ECMAScript features are prefixed with es.